### PR TITLE
fix: Readd states to individual task page

### DIFF
--- a/pages/tasks/[taskId].tsx
+++ b/pages/tasks/[taskId].tsx
@@ -130,10 +130,27 @@ export async function getServerSideProps(context) {
 		(res) => res.json()
 	);
 
+	const states = await fetch(`${API_ENDPOINT}/taskStateUI`).then((res) =>
+		res.json()
+	);
+
 	return {
 		props: {
 			lugbot,
 			project: projects[0],
+			states: {
+				byName: states,
+				byState: Object.values(states).reduce((acc, state: object) => {
+					// @ts-ignore: state.state is not properly recognised
+					acc[state.state] = state;
+
+					return acc;
+				}, {}),
+				completedFailureState: states.completedFailure,
+				completedSuccessState: states.completedSuccess,
+				pendingState: states.pending,
+				runningState: states.running,
+			},
 			task,
 			taskLog,
 		},


### PR DESCRIPTION
I had to readd `states` and keep the server side handling because otherwise I'd have to specify all of the task ids that could be rendered, as per https://nextjs.org/docs/basic-features/data-fetching#getstaticpaths-static-generation